### PR TITLE
Setup the demo to let Pixie trace Mongo traffic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.0"
+
+services:
+    front:
+        build:
+            context: ./src/front/
+            dockerfile: ../../dockerfiles/Dockerfile.front
+        ports:
+            - 8080:8080
+        depends_on:
+            - back
+        image: gcr.io/pixie-prod/demos/px-mongo/frontend:0.1.0
+
+    back:
+        build:
+            context: ./src/back
+            dockerfile: ../../dockerfiles/Dockerfile.back
+        ports:
+            - 8085:8085
+        depends_on:
+            - mongodb
+        environment:
+            - PORT=8085
+            - CONN_STR=mongodb://mongodb:27017
+        image: back:latest
+
+    load:
+        build:
+            context: ./src/load-test
+            dockerfile: ../../dockerfiles/Dockerfile.load
+        depends_on:
+            - back
+        image: load:latest
+
+    mongodb:
+        image: mongo:latest
+        container_name: mongodb
+        restart: always
+        ports:
+            - 27017:27017

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             - 8080:8080
         depends_on:
             - back
-        image: gcr.io/pixie-prod/demos/px-mongo/frontend:0.1.0
+        image: gcr.io/pixie-prod/demos/px-mongo/frontend:1.0.0
 
     back:
         build:
@@ -22,7 +22,7 @@ services:
         environment:
             - PORT=8085
             - CONN_STR=mongodb://mongodb:27017
-        image: back:latest
+        image: gcr.io/pixie-prod/demos/px-mongo/backend:1.0.0
 
     load:
         build:
@@ -30,10 +30,10 @@ services:
             dockerfile: ../../dockerfiles/Dockerfile.load
         depends_on:
             - back
-        image: load:latest
+        image: gcr.io/pixie-prod/demos/px-mongo/load:1.0.0
 
     mongodb:
-        image: mongo:latest
+        image: mongo:7.0
         container_name: mongodb
         restart: always
         ports:

--- a/dockerfiles/Dockerfile.load
+++ b/dockerfiles/Dockerfile.load
@@ -1,0 +1,9 @@
+FROM python:3.12
+
+WORKDIR /opt/app
+
+RUN pip install locust
+
+COPY ./locustfile.py .
+
+CMD ["locust", "-f", "locustfile.py", "--headless", "-u", "100", "-r", "5", "--host", "http://back:8085"]

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,7 @@
+## Build instructions
+
+* The kubernetes manifests are created through kompose by converting the docker-compose file.
+```bash
+cd kubernetes
+kompose convert -f ../docker-compose.yml
+```

--- a/kubernetes/back-deployment.yaml
+++ b/kubernetes/back-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: mongodb://mongodb:27017
         - name: PORT
           value: "8085"
-        image: back:latest
+        image: gcr.io/pixie-prod/demos/px-mongo/backend:1.0.0
         imagePullPolicy: ""
         name: back
         ports:

--- a/kubernetes/back-deployment.yaml
+++ b/kubernetes/back-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: back
+  name: back
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: back
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: back
+    spec:
+      containers:
+      - env:
+        - name: CONN_STR
+          value: mongodb://mongodb:27017
+        - name: PORT
+          value: "8085"
+        image: back:latest
+        imagePullPolicy: ""
+        name: back
+        ports:
+        - containerPort: 8085
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}

--- a/kubernetes/back-service.yaml
+++ b/kubernetes/back-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: back
+  name: back
+spec:
+  ports:
+  - name: "8085"
+    port: 8085
+    targetPort: 8085
+  selector:
+    io.kompose.service: back
+status:
+  loadBalancer: {}

--- a/kubernetes/front-deployment.yaml
+++ b/kubernetes/front-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         io.kompose.service: front
     spec:
       containers:
-      - image: gcr.io/pixie-prod/demos/px-mongo/frontend:0.1.0
+      - image: gcr.io/pixie-prod/demos/px-mongo/frontend:1.0.0
         imagePullPolicy: ""
         name: front
         ports:

--- a/kubernetes/front-deployment.yaml
+++ b/kubernetes/front-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: front
+  name: front
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: front
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: front
+    spec:
+      containers:
+      - image: gcr.io/pixie-prod/demos/px-mongo/frontend:0.1.0
+        imagePullPolicy: ""
+        name: front
+        ports:
+        - containerPort: 8080
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}

--- a/kubernetes/front-service.yaml
+++ b/kubernetes/front-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: front
+  name: front
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 8080
+  selector:
+    io.kompose.service: front
+status:
+  loadBalancer: {}

--- a/kubernetes/load-deployment.yaml
+++ b/kubernetes/load-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: load
+  name: load
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: load
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: load
+    spec:
+      containers:
+      - image: load:latest
+        imagePullPolicy: ""
+        name: load
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}

--- a/kubernetes/load-deployment.yaml
+++ b/kubernetes/load-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         io.kompose.service: load
     spec:
       containers:
-      - image: load:latest
+      - image: gcr.io/pixie-prod/demos/px-mongo/load:1.0.0
         imagePullPolicy: ""
         name: load
         resources: {}

--- a/kubernetes/mongodb-deployment.yaml
+++ b/kubernetes/mongodb-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: mongodb
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+        kompose.version: 1.21.0 (992df58d8)
+      creationTimestamp: null
+      labels:
+        io.kompose.service: mongodb
+    spec:
+      containers:
+      - image: mongo:latest
+        imagePullPolicy: ""
+        name: mongodb
+        ports:
+        - containerPort: 27017
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}

--- a/kubernetes/mongodb-deployment.yaml
+++ b/kubernetes/mongodb-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         io.kompose.service: mongodb
     spec:
       containers:
-      - image: mongo:latest
+      - image: mongo:7.0
         imagePullPolicy: ""
         name: mongodb
         ports:

--- a/kubernetes/mongodb-service.yaml
+++ b/kubernetes/mongodb-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: /snap/kompose/19/kompose-linux-amd64 convert -f ../docker-compose.yml
+    kompose.version: 1.21.0 (992df58d8)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: mongodb
+  name: mongodb
+spec:
+  ports:
+  - name: "27017"
+    port: 27017
+    targetPort: 27017
+  selector:
+    io.kompose.service: mongodb
+status:
+  loadBalancer: {}

--- a/src/back/index.js
+++ b/src/back/index.js
@@ -76,5 +76,21 @@ app.get("/clear", async (req, res) => {
     }
     res.send(result).status(200);
 })
+
+app.put("/update", async (req, res) => {
+  log("/update", `PUT request ${JSON.stringify(req.body)}`);
+  let result;
+  try {
+    let collection = await db.collection("entries");
+    let filter = {};
+    result = await collection.updateOne(
+      filter,
+      {$set: req.body},
+    );
+  } catch(e) {
+    log("/update", e.toString());
+  }
+  res.send(result).status(200);
+})
   
 app.listen(PORT, () => console.log(`Server started on port ${PORT}`));

--- a/src/load-test/locustfile.py
+++ b/src/load-test/locustfile.py
@@ -1,0 +1,41 @@
+import random
+from locust import HttpUser, TaskSet, between
+
+headers = {'Content-Type': 'application/json'}
+
+places = [
+    'San Francisco',
+    'Los Angeles',
+    'Rome',
+    'Milan',
+    'Geneva',
+    'Dubai',
+    'New York City',
+    'Montreal',
+    'Tokyo']
+
+def insert(l):
+    l.client.post("/entry", json={'place': random.choice(places)}, headers=headers)
+
+def get(l):
+    l.client.get("/entries")
+
+def delete(l):
+    l.client.get("/clear")
+
+def update(l):
+    l.client.put("/update", json={'place': random.choice(places)}, headers=headers)
+
+class UserBehavior(TaskSet):
+
+    def on_start(self):
+       insert(self)
+
+    tasks = {insert: 2,
+        get: 1,
+        update: 1,
+        delete: 1}
+
+class WebsiteUser(HttpUser):
+    tasks = [UserBehavior]
+    wait_time = between(7, 10)


### PR DESCRIPTION
Summary: This PR makes changes to the existing demo to allow Pixie to trace mongo traffic within the cluster. This PR is a continuation from [here](https://github.com/kpattaswamy/mern-k8s/pull/1)